### PR TITLE
Skip building extension if buildkit file is not changed

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,76 @@
+name: Build
+on:
+  workflow_call:
+    inputs:
+      extensions:
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      extensions:
+        required: true
+        type: string
+jobs:
+  set_matrix:
+    name: Set Matrix
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v3
+      - id: set-matrix
+        run: |
+          extensions=$(./script/list-extensions "${{ github.event.inputs.extensions }}")
+          echo "matrix=$extensions" >> "$GITHUB_OUTPUT"
+  build:
+    name: Build Extensions
+    runs-on: ${{ matrix.runs-on }}
+    needs: set_matrix
+    strategy:
+      fail-fast: false
+      matrix:
+        arch:
+          - amd64
+          - arm64
+        extension: ${{ fromJSON(needs.set_matrix.outputs.matrix) }}
+        include:
+          - arch: amd64
+            runs-on: buildjet-4vcpu-ubuntu-2204
+          - arch: arm64
+            runs-on: buildjet-4vcpu-ubuntu-2204-arm
+    steps:
+      - uses: actions/checkout@v3
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v37
+        with:
+          files: buildkit/${{ matrix.extension }}.yaml
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to ghcr.io
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install pgxman
+        env:
+          REPO: pgxman/pgxman
+        run: |
+          wget -O /tmp/pgxman_linux_${{ matrix.arch }}.deb https://github.com/pgxman/release/releases/latest/download/pgxman_linux_${{ matrix.arch }}.deb
+          sudo apt install /tmp/pgxman_linux_${{ matrix.arch }}.deb -y
+      - name: Build
+        run: |
+          pgxman build \
+            --file "$(pwd)/buildkit/${{ matrix.extension }}.yaml" \
+            --set "arch=[${{ matrix.arch }}]" \
+            --cache-from "type=registry,ref=ghcr.io/pgxman/buildkit-cache" \
+            --cache-to "type=registry,ref=ghcr.io/pgxman/buildkit-cache,mode=max"
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ matrix.extension }}
+          if-no-files-found: error
+          retention-days: 7
+          path: |
+            out/*.*

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v3
       - id: set-matrix
         run: |
-          extensions=$(./script/list-extensions "${{ github.event.inputs.extensions }}")
+          extensions=$(./script/list-extensions "${{ inputs.extensions }}")
           echo "matrix=$extensions" >> "$GITHUB_OUTPUT"
   build:
     name: Build Extensions

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,8 +20,8 @@ jobs:
         with:
           files: |
             buildkit/*.yaml
-            .github/workflow/*.*
-            script/*.*
+            .github/workflows/**
+            script/**
       - id: detect-changed-files
         run: |
           changed_extensions=$(script/changed-extensions ${{ steps.changed-files.outputs.all_changed_files }})

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,15 +25,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on:
-          - buildjet-4vcpu-ubuntu-2204
-          - buildjet-4vcpu-ubuntu-2204-arm
+        arch:
+          - amd64
+          - arm64
         extension: ${{ fromJSON(needs.set_matrix.outputs.matrix) }}
         include:
-          - runs-on: buildjet-4vcpu-ubuntu-2204
-            arch: amd64
-          - runs-on: buildjet-4vcpu-ubuntu-2204-arm
-            arch: arm64
+          - arch: amd64
+            runs-on: buildjet-4vcpu-ubuntu-2204
+          - arch: arm64
+            runs-on: buildjet-4vcpu-ubuntu-2204-arm
     steps:
       - uses: actions/checkout@v3
       - name: Get changed files
@@ -42,27 +42,27 @@ jobs:
         with:
           files: |
             buildkit/${{ matrix.extension }}.yaml
-            .github/workflows/**
-            script/**
+            .github/workflow/*
+            script/*
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-        if: ${{ steps.changed-files.outputs.any_changed == true }}
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
       - name: Login to ghcr.io
         uses: docker/login-action@v2
-        if: ${{ steps.changed-files.outputs.any_changed == true }}
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Install pgxman
-        if: ${{ steps.changed-files.outputs.any_changed == true }}
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
         env:
           REPO: pgxman/pgxman
         run: |
           wget -O /tmp/pgxman_linux_${{ matrix.arch }}.deb https://github.com/pgxman/release/releases/latest/download/pgxman_linux_${{ matrix.arch }}.deb
           sudo apt install /tmp/pgxman_linux_${{ matrix.arch }}.deb -y
       - name: Build
-        if: ${{ steps.changed-files.outputs.any_changed == true }}
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
         run: |
           pgxman build \
             --file "$(pwd)/buildkit/${{ matrix.extension }}.yaml" \
@@ -71,7 +71,7 @@ jobs:
             --cache-to "type=registry,ref=ghcr.io/pgxman/buildkit-cache,mode=max"
       - name: Upload Artifacts
         uses: actions/upload-artifact@v3
-        if: ${{ steps.changed-files.outputs.any_changed == true }}
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
         with:
           name: ${{ matrix.extension }}
           if-no-files-found: error

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,14 +20,13 @@ jobs:
         with:
           files: |
             buildkit/*.yaml
-            .github/workflow/*
-            script/*
+            .github/workflow/*.*
+            script/*.*
       - id: detect-changed-files
         run: |
-          for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
-            echo "$file was changed"
-          done
-          echo "changed_extensions=.+" >> "$GITHUB_OUTPUT"
+          changed_extensions=$(script/changed-extensions ${{ steps.changed-files.outputs.all_changed_files }})
+          echo "$changed_extensions"
+          echo "changed_extensions=$changed_extensions" >> "$GITHUB_OUTPUT"
   build:
     name: Build Extensions
     needs: [detect_changed_extensions]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,21 +36,33 @@ jobs:
             arch: arm64
     steps:
       - uses: actions/checkout@v3
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v37
+        with:
+          files: |
+            buildkit/${{ matrix.extension }}.yaml
+            .github/workflows/**
+            script/**
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
+        if: ${{ steps.changed-files.outputs.any_changed == true }}
       - name: Login to ghcr.io
         uses: docker/login-action@v2
+        if: ${{ steps.changed-files.outputs.any_changed == true }}
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Install pgxman
+        if: ${{ steps.changed-files.outputs.any_changed == true }}
         env:
           REPO: pgxman/pgxman
         run: |
           wget -O /tmp/pgxman_linux_${{ matrix.arch }}.deb https://github.com/pgxman/release/releases/latest/download/pgxman_linux_${{ matrix.arch }}.deb
           sudo apt install /tmp/pgxman_linux_${{ matrix.arch }}.deb -y
       - name: Build
+        if: ${{ steps.changed-files.outputs.any_changed == true }}
         run: |
           pgxman build \
             --file "$(pwd)/buildkit/${{ matrix.extension }}.yaml" \
@@ -59,6 +71,7 @@ jobs:
             --cache-to "type=registry,ref=ghcr.io/pgxman/buildkit-cache,mode=max"
       - name: Upload Artifacts
         uses: actions/upload-artifact@v3
+        if: ${{ steps.changed-files.outputs.any_changed == true }}
         with:
           name: ${{ matrix.extension }}
           if-no-files-found: error

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,33 +7,11 @@ on:
   workflow_call:
   workflow_dispatch:
 jobs:
-  set_matrix:
-    name: Set Matrix
+  detect_changed_extensions:
+    name: Detect changed extensions
     runs-on: ubuntu-latest
     outputs:
-      matrix: ${{ steps.set-matrix.outputs.matrix }}
-    steps:
-      - uses: actions/checkout@v3
-      - id: set-matrix
-        run: |
-          extensions=$(./script/list-extensions)
-          echo "matrix=$extensions" >> "$GITHUB_OUTPUT"
-  build:
-    name: Build Extensions
-    runs-on: ${{ matrix.runs-on }}
-    needs: set_matrix
-    strategy:
-      fail-fast: false
-      matrix:
-        arch:
-          - amd64
-          - arm64
-        extension: ${{ fromJSON(needs.set_matrix.outputs.matrix) }}
-        include:
-          - arch: amd64
-            runs-on: buildjet-4vcpu-ubuntu-2204
-          - arch: arm64
-            runs-on: buildjet-4vcpu-ubuntu-2204-arm
+      changed_extensions: ${{ steps.detect-changed-files.outputs.changed_extensions }}
     steps:
       - uses: actions/checkout@v3
       - name: Get changed files
@@ -41,43 +19,22 @@ jobs:
         uses: tj-actions/changed-files@v37
         with:
           files: |
-            buildkit/${{ matrix.extension }}.yaml
+            buildkit/*.yaml
             .github/workflow/*
             script/*
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-        if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
-      - name: Login to ghcr.io
-        uses: docker/login-action@v2
-        if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Install pgxman
-        if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
-        env:
-          REPO: pgxman/pgxman
+      - id: detect-changed-files
         run: |
-          wget -O /tmp/pgxman_linux_${{ matrix.arch }}.deb https://github.com/pgxman/release/releases/latest/download/pgxman_linux_${{ matrix.arch }}.deb
-          sudo apt install /tmp/pgxman_linux_${{ matrix.arch }}.deb -y
-      - name: Build
-        if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
-        run: |
-          pgxman build \
-            --file "$(pwd)/buildkit/${{ matrix.extension }}.yaml" \
-            --set "arch=[${{ matrix.arch }}]" \
-            --cache-from "type=registry,ref=ghcr.io/pgxman/buildkit-cache" \
-            --cache-to "type=registry,ref=ghcr.io/pgxman/buildkit-cache,mode=max"
-      - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
-        if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
-        with:
-          name: ${{ matrix.extension }}
-          if-no-files-found: error
-          retention-days: 7
-          path: |
-            out/*.*
+          for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
+            echo "$file was changed"
+          done
+          echo "changed_extensions=.+" >> "$GITHUB_OUTPUT"
+  build:
+    name: Build Extensions
+    needs: [detect_changed_extensions]
+    uses: ./.github/workflows/build.yaml
+    with:
+      extensions: ${{ needs.detect_changed_extensions.outputs.changed_extensions }}
+    secrets: inherit
   publish:
     name: Publish Extensions
     runs-on: ubuntu-latest

--- a/buildkit/multicorn_gspreadsheet_fdw.yaml
+++ b/buildkit/multicorn_gspreadsheet_fdw.yaml
@@ -3,7 +3,7 @@ name: multicorn_gspreadsheet_fdw
 version: "1.0.0+d5bc5ae"
 homepage: https://github.com/hydradatabase/gspreadsheet_fdw
 source: https://github.com/hydradatabase/gspreadsheet_fdw/archive/d5bc5ae0b2d189abd6d2ee4610bd96ec39602594.tar.gz
-description: Multicorn Google Spreadsheets Foreign Data Wrapper
+description: Multicorn Google Spreadsheets Foreign Data Wrapper.
 keywords:
   - python3
   - multicorn

--- a/buildkit/multicorn_s3csv_fdw.yaml
+++ b/buildkit/multicorn_s3csv_fdw.yaml
@@ -3,7 +3,7 @@ name: multicorn_s3csv_fdw
 version: "1.0.0+f64e24f"
 homepage: https://github.com/hydradatabase/s3csv_fdw
 source: https://github.com/hydradatabase/s3csv_fdw/archive/f64e24f9fe3f7dbd1be76f9b8b3b5208f869e5e3.tar.gz
-description: Multicorn S3 CSV Foreign Data Wrapper
+description: Multicorn S3 CSV Foreign Data Wrapper.
 keywords:
   - python3
   - multicorn

--- a/buildkit/mysql_fdw.yaml
+++ b/buildkit/mysql_fdw.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 name: mysql_fdw
 version: 2.9.1
 source: https://github.com/EnterpriseDB/mysql_fdw/archive/refs/tags/REL-2_9_1.tar.gz
-description: MySQL Foreign Data Wrapper for PostgreSQL
+description: MySQL Foreign Data Wrapper for PostgreSQL.
 keywords:
   - mysql
   - fdw

--- a/buildkit/pgvector.yaml
+++ b/buildkit/pgvector.yaml
@@ -3,7 +3,7 @@ name: pgvector
 version: "0.4.4"
 homepage: https://github.com/pgvector/pgvector
 source: https://github.com/pgvector/pgvector/archive/refs/tags/v0.4.4.tar.gz
-description: Open-source vector similarity search for Postgres
+description: Open-source vector similarity search for Postgres.
 keywords:
   - nearest-neighbor-search
   - approximate-nearest-neighbor-search

--- a/script/changed-extensions
+++ b/script/changed-extensions
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+changed_extensions=()
+for file in "$@"; do
+    if [[ $file == .github/* ]]; then
+        echo ".+"
+        exit
+    fi
+
+    if [[ $file == script/* ]]; then
+        echo ".+"
+        exit
+    fi
+
+    changed_extensions+=("$(basename "$file" .yaml)")
+done
+
+printf -v regexp '|%s' "${changed_extensions[@]}"
+echo "${regexp:1}"

--- a/script/list-extensions
+++ b/script/list-extensions
@@ -1,7 +1,15 @@
 #!/usr/bin/env bash
 
-VAR=$(find . -name 'extension.yaml' -printf "%h " | sed 's/\.\///g')
-VAR=$(ls buildkit/*.yaml | sed -r 's/buildkit\/(.+)\.yaml/\1/g')
-arr=($VAR)
+set -euo pipefail
 
-jq -nc '[ $ARGS.positional[] ]' --args ${arr[@]}
+buildkit=$(find buildkit -name '*.yaml' | sed -r 's/buildkit\/(.+)\.yaml/\1/g')
+arr=("$buildkit")
+
+# shellcheck disable=SC2068
+result=$(jq -nc '[ $ARGS.positional[] ]' --args ${arr[@]})
+
+if [ $# -eq 0 ]; then
+    echo "$result"
+else
+    echo "$result" | jq -rcM "[.[] | select(.|test(\"^$1\$\"))]"
+fi


### PR DESCRIPTION
Skip building extension if buildkit file is not changed with the exception that any files changed in `.github/workflows/*` & `script/*` will rebuild everything.