### PR TITLE
Be explicit about Python deps for muticorn* buildkit

### DIFF
--- a/buildkit/multicorn.yaml
+++ b/buildkit/multicorn.yaml
@@ -26,6 +26,10 @@ build:
         DEST_PYTHON_DIR=${DESTDIR}/usr/local/lib/python3.11/dist-packages
         mkdir -p ${DEST_PYTHON_DIR}
         cp -r .venv/lib/python3.11/site-packages/multicorn ${DEST_PYTHON_DIR}
+buildDependencies:
+  - python3.11
+  - python3.11-dev
+  - python3.11-venv
 pgVersions:
   - "13"
   - "14"

--- a/buildkit/multicorn_gspreadsheet_fdw.yaml
+++ b/buildkit/multicorn_gspreadsheet_fdw.yaml
@@ -30,5 +30,9 @@ pgVersions:
   - "13"
   - "14"
   - "15"
+buildDependencies:
+  - python3.11
+  - python3.11-dev
+  - python3.11-venv
 dependencies:
   - pgxman/multicorn

--- a/buildkit/multicorn_s3csv_fdw.yaml
+++ b/buildkit/multicorn_s3csv_fdw.yaml
@@ -31,5 +31,9 @@ pgVersions:
   - "13"
   - "14"
   - "15"
+buildDependencies:
+  - python3.11
+  - python3.11-dev
+  - python3.11-venv
 dependencies:
   - pgxman/multicorn


### PR DESCRIPTION
The builder image has the Python deps but it would be more clear to declar them explicitly as part of the muticorn* buildkit too.