### PR TITLE
Add multicorn runDependencies

### DIFF
--- a/buildkit/multicorn.yaml
+++ b/buildkit/multicorn.yaml
@@ -35,6 +35,9 @@ buildDependencies:
   - python3.11
   - python3.11-dev
   - python3.11-venv
+runDependencies:
+  - python3.11
+  - python3.11-dev
 pgVersions:
   - "13"
   - "14"


### PR DESCRIPTION
Add multicorn runDependencies and we could skip installing in the run image: https://github.com/hydradatabase/hydra/blob/d0d05da5dad31036e82a0290a1ade73af7f7948e/Dockerfile.spilo#L20-L21