### PR TITLE
[HYD-505] Backfill licenses

### DIFF
--- a/buildkit/hydra_columnar.yaml
+++ b/buildkit/hydra_columnar.yaml
@@ -4,6 +4,7 @@ version: 1.0.0-beta
 homepage: https://github.com/hydradatabase/hydra
 source: https://github.com/hydradatabase/hydra/archive/refs/tags/v1.0.0-beta.tar.gz
 description: Hydra columnar extension for PostgreSQL.
+license: AGPL-3.0
 build:
   main:
     - name: Build hydra_columnar

--- a/buildkit/multicorn.yaml
+++ b/buildkit/multicorn.yaml
@@ -4,6 +4,7 @@ version: "2.4+b68b75c"
 homepage: https://github.com/pgsql-io/multicorn2
 source: https://github.com/pgsql-io/multicorn2/archive/b68b75c253be72bdfd5b24bf76705c47c238d370.tar.gz
 description: Multicorn Python3 Wrapper for Postgresql Foreign Data Wrapper. This includes the s3csv_fdw and gspreadsheet_fdw plugins.
+license: PostgreSQL
 keywords:
   - python3
   - multicorn

--- a/buildkit/mysql_fdw.yaml
+++ b/buildkit/mysql_fdw.yaml
@@ -1,8 +1,10 @@
 apiVersion: v1
 name: mysql_fdw
 version: 2.9.1
+homepage: https://github.com/EnterpriseDB/mysql_fdw
 source: https://github.com/EnterpriseDB/mysql_fdw/archive/refs/tags/REL-2_9_1.tar.gz
 description: MySQL Foreign Data Wrapper for PostgreSQL.
+license: PostgreSQL
 keywords:
   - mysql
   - fdw

--- a/buildkit/parquet_s3_fdw.yaml
+++ b/buildkit/parquet_s3_fdw.yaml
@@ -4,6 +4,7 @@ version: "1.0.0+5298b7f"
 homepage: https://github.com/hydradatabase/parquet_s3_fdw
 source: https://github.com/hydradatabase/parquet_s3_fdw/archive/5298b7f0254923f52d15e554ec8a5fdc0474f059.tar.gz
 description: Parquet S3 Foreign Data Wrapper for PostgreSQL.
+license: PostgreSQL
 keywords:
   - fdw
   - parquet

--- a/buildkit/pg_hint_plan-13.yaml
+++ b/buildkit/pg_hint_plan-13.yaml
@@ -1,19 +1,21 @@
 apiVersion: v1
 build:
   main:
-  - name: build step
-    run: |
-      make
-      DESTDIR=${DESTDIR} make install
+    - name: build step
+      run: |
+        make
+        DESTDIR=${DESTDIR} make install
 keywords:
-- hint
-- plan
-- index
+  - hint
+  - plan
+  - index
 maintainers:
-- email: jd@hydra.so
-  name: Jonathan Dance
+  - email: jd@hydra.so
+    name: Jonathan Dance
 name: pg_hint_plan-13
 pgVersions:
-- "13"
+  - "13"
 source: https://github.com/ossc-db/pg_hint_plan/archive/refs/tags/REL13_1_3_8.tar.gz
+license: BSD-3-Clause AND PostgreSQL
+homepage: https://github.com/ossc-db/pg_hint_plan
 version: 1.3.8-1

--- a/buildkit/pg_hint_plan-14.yaml
+++ b/buildkit/pg_hint_plan-14.yaml
@@ -1,19 +1,21 @@
 apiVersion: v1
 build:
   main:
-  - name: build step
-    run: |
-      make
-      DESTDIR=${DESTDIR} make install
+    - name: build step
+      run: |
+        make
+        DESTDIR=${DESTDIR} make install
 keywords:
-- hint
-- plan
-- index
+  - hint
+  - plan
+  - index
 maintainers:
-- email: jd@hydra.so
-  name: Jonathan Dance
+  - email: jd@hydra.so
+    name: Jonathan Dance
 name: pg_hint_plan-14
 pgVersions:
-- "14"
+  - "14"
 source: https://github.com/ossc-db/pg_hint_plan/archive/refs/tags/REL14_1_4_1.tar.gz
+license: BSD-3-Clause AND PostgreSQL
+homepage: https://github.com/ossc-db/pg_hint_plan
 version: 1.4.1-1

--- a/buildkit/pg_hint_plan-15.yaml
+++ b/buildkit/pg_hint_plan-15.yaml
@@ -1,19 +1,21 @@
 apiVersion: v1
 build:
   main:
-  - name: build step
-    run: |
-      make
-      DESTDIR=${DESTDIR} make install
+    - name: build step
+      run: |
+        make
+        DESTDIR=${DESTDIR} make install
 keywords:
-- hint
-- plan
-- index
+  - hint
+  - plan
+  - index
 maintainers:
-- email: jd@hydra.so
-  name: Jonathan Dance
+  - email: jd@hydra.so
+    name: Jonathan Dance
 name: pg_hint_plan-15
 pgVersions:
-- "15"
+  - "15"
 source: https://github.com/ossc-db/pg_hint_plan/archive/refs/tags/REL15_1_5_0.tar.gz
+license: BSD-3-Clause AND PostgreSQL
+homepage: https://github.com/ossc-db/pg_hint_plan
 version: 1.5.0-1

--- a/buildkit/pg_ivm.yaml
+++ b/buildkit/pg_ivm.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 name: pg_ivm
 version: 1.5.1
 homepage: https://github.com/sraoss/pg_ivm
+license: PostgreSQL
 source: https://github.com/sraoss/pg_ivm/archive/refs/tags/v1.5.1.tar.gz
 description: IVM (Incremental View Maintenance) implementation as a PostgreSQL extension.
 build:

--- a/buildkit/pgsql-http.yaml
+++ b/buildkit/pgsql-http.yaml
@@ -4,6 +4,7 @@ version: "1.5.0"
 homepage: https://github.com/pramsey/pgsql-http
 source: https://github.com/pramsey/pgsql-http/archive/refs/tags/v1.5.0.tar.gz
 description: HTTP client for PostgreSQL, retrieve a web page from inside the database.
+license: MIT
 keywords:
   - http
 arch:

--- a/buildkit/pgvector.yaml
+++ b/buildkit/pgvector.yaml
@@ -4,6 +4,7 @@ version: "0.4.4"
 homepage: https://github.com/pgvector/pgvector
 source: https://github.com/pgvector/pgvector/archive/refs/tags/v0.4.4.tar.gz
 description: Open-source vector similarity search for Postgres.
+license: PostgreSQL
 keywords:
   - nearest-neighbor-search
   - approximate-nearest-neighbor-search


### PR DESCRIPTION
Backfill licenses to all extensions. Some extensions do not have a exact match of license content even GitHub can't detect:

* mysql_fdw
* parquet_s3_fdw
* pg_hint_plan
* pg_ivm
* pgvector

I try my best guess to match a compatible license in this case.