### PR TITLE
Preserve old versions of debian packages

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,9 +53,7 @@ jobs:
           ref: ee4fb051073a8387c9d3d5275a41194b62942c83
       - name: Install deb-s3
         run: |
-          cd deb-s3
-          gem build
-          gem install deb-s3-0.11.7.gem
+          gem install deb-s3
       - name: Import GPG Key
         env:
           GPG_PRIVATE: ${{ secrets.GPG_PRIVATE }}

--- a/script/deb-s3-upload
+++ b/script/deb-s3-upload
@@ -16,5 +16,6 @@ for _dir in $_dirs; do
         --codename "$_codename" \
         --visibility public \
         --sign "$GPG_SIGNING_KEY_ID" \
+        --preserve_versions \
         "$*/$_dir/*.deb"
 done


### PR DESCRIPTION
Preserve old versions of debian packages. Unfortunately, pgvector=0.4.4 was removed from the index although the package is still in S3. But this won't happen moving forward.