### PR TITLE
[HYD-555] Add postgresql_anonymizer buildkit

### DIFF
--- a/buildkit/postgresql_anonymizer.yaml
+++ b/buildkit/postgresql_anonymizer.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+name: postgresql_anonymizer
+version: "1.1.0+acc2aa3f"
+homepage: https://gitlab.com/dalibo/postgresql_anonymizer
+source: https://gitlab.com/dalibo/postgresql_anonymizer/-/archive/acc2aa3f2c4f0eb74027cdc9b4b25f8beb2a2e93/postgresql_anonymizer-acc2aa3f2c4f0eb74027cdc9b4b25f8beb2a2e93.tar.gz
+description: An extension to mask or replace Personally Identifiable Information (PII) or commercially sensitive data from a PostgreSQL database.
+license: PostgreSQL
+keywords:
+  - pii
+arch:
+  - amd64
+  - arm64
+maintainers:
+  - name: Owen Ou
+    email: o@hydra.so
+build:
+  main:
+    - name: Build postgresql_anonymizer
+      run: |
+        make extension
+        DESTDIR=${DESTDIR} make install
+pgVersions:
+  - "13"
+  - "14"
+  - "15"
+  - "16"


### PR DESCRIPTION
Add postgresql_anonymizer buildkit. [1.1.0](https://gitlab.com/dalibo/postgresql_anonymizer/-/tree/1.1.0?ref_type=tags) was created a year ago without pg 16 support. This buildkit builds from the [latest commit](https://gitlab.com/dalibo/postgresql_anonymizer/-/commit/acc2aa3f2c4f0eb74027cdc9b4b25f8beb2a2e93)