### PR TITLE
merge: rum, hypopg and pgrouting support, spec update

### DIFF
--- a/buildkit/hypopg.yaml
+++ b/buildkit/hypopg.yaml
@@ -7,7 +7,8 @@ source: https://github.com/HypoPG/hypopg/archive/refs/tags/1.4.0.tar.gz
 description: Hypothetical Indexes for PostgreSQL
 licence: PostgreSQL
 keywords:
-  - hypopg
+  - hypothetical indexes
+  - virtual indexes
 arch:
   - amd64
   - arm64

--- a/buildkit/hypopg.yaml
+++ b/buildkit/hypopg.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+name: hypopg
+version: "1.4.0"
+homepage: https://github.com/HypoPG/hypopg
+source: https://github.com/HypoPG/hypopg/archive/refs/tags/1.4.0.tar.gz
+description: Hypothetical Indexes for PostgreSQL
+licence: PostgreSQL
+keywords:
+  - hypopg
+arch:
+  - amd64
+  - arm64
+maintainers:
+  - name: James Lovern
+    email: james@lovern.io
+build:
+  main:
+    - name: Build hypopg
+      run: |
+        make
+        DESTDIR=${DESTDIR} make install
+pgVersions:
+  - "9.2"
+  - "10"
+  - "11"
+  - "12"
+  - "13"
+  - "14"
+  - "15"
+  - "16"

--- a/buildkit/hypopg.yaml
+++ b/buildkit/hypopg.yaml
@@ -20,10 +20,6 @@ build:
         make
         DESTDIR=${DESTDIR} make install
 pgVersions:
-  - "9.2"
-  - "10"
-  - "11"
-  - "12"
   - "13"
   - "14"
   - "15"

--- a/buildkit/hypopg.yaml
+++ b/buildkit/hypopg.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 name: hypopg
 version: "1.4.0"
 homepage: https://github.com/HypoPG/hypopg
+repository: https://github.com/HypoPG/hypopg
 source: https://github.com/HypoPG/hypopg/archive/refs/tags/1.4.0.tar.gz
 description: Hypothetical Indexes for PostgreSQL
 licence: PostgreSQL

--- a/buildkit/pgrouting.yaml
+++ b/buildkit/pgrouting.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+name: pgrouting
+version: "3.5.1"
+homepage: https://github.com/pgRouting/pgrouting
+source: https://github.com/pgRouting/pgrouting/releases/download/v3.5.1/pgrouting-3.5.1.tar.gz
+description: pgRouting extends the PostGIS/PostgreSQL geospatial database to provide geospatial routing and other network analysis functionality.
+licence: GPL-2.0 AND BSL-1.0
+keywords:
+  - pgrouting
+arch:
+  - amd64
+  - arm64
+maintainers:
+  - name: James Lovern
+    email: james@lovern.io
+build:
+  main:
+    - name: Build pgrouting
+      run: |
+        mkdir build
+        cd build
+        cmake -DCMAKE_INSTALL_PREFIX=/usr/local ..
+        make
+        DESTDIR=${DESTDIR} make install
+buildDependencies:
+  - libboost-all-dev
+pgVersions:
+  - "16"

--- a/buildkit/pgrouting.yaml
+++ b/buildkit/pgrouting.yaml
@@ -5,9 +5,9 @@ homepage: https://github.com/pgRouting/pgrouting
 repository: https://github.com/pgRouting/pgrouting
 source: https://github.com/pgRouting/pgrouting/releases/download/v3.5.1/pgrouting-3.5.1.tar.gz
 description: pgRouting extends the PostGIS/PostgreSQL geospatial database to provide geospatial routing and other network analysis functionality.
-licence: GPL-2.0 AND BSL-1.0
+licence: GPL-2.0-or-later
 keywords:
-  - pgrouting
+  - geospatial routing
 arch:
   - amd64
   - arm64

--- a/buildkit/pgrouting.yaml
+++ b/buildkit/pgrouting.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 name: pgrouting
 version: "3.5.1"
 homepage: https://github.com/pgRouting/pgrouting
+repository: https://github.com/pgRouting/pgrouting
 source: https://github.com/pgRouting/pgrouting/releases/download/v3.5.1/pgrouting-3.5.1.tar.gz
 description: pgRouting extends the PostGIS/PostgreSQL geospatial database to provide geospatial routing and other network analysis functionality.
 licence: GPL-2.0 AND BSL-1.0

--- a/buildkit/rum.yaml
+++ b/buildkit/rum.yaml
@@ -22,10 +22,6 @@ build:
 buildDependencies:
   - systemtap-sdt-dev
 pgVersions:
-  - "9.6"
-  - "10"
-  - "11"
-  - "12"
   - "13"
   - "14"
   - "15"

--- a/buildkit/rum.yaml
+++ b/buildkit/rum.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+name: rum
+version: "1.3.13"
+homepage: https://github.com/postgrespro/rum
+source: https://github.com/postgrespro/rum/archive/refs/tags/1.3.13.tar.gz
+description: RUM access method - inverted index with additional information in posting lists
+licence: PostgreSQL
+keywords:
+  - rum
+arch:
+  - amd64
+  - arm64
+maintainers:
+  - name: James Lovern
+    email: james@lovern.io
+build:
+  main:
+    - name: Build RUM
+      run: |
+        make USE_PGXS=1
+        DESTDIR=${DESTDIR} make USE_PGXS=1 install
+buildDependencies:
+  - systemtap-sdt-dev
+pgVersions:
+  - "9.6"
+  - "10"
+  - "11"
+  - "12"
+  - "13"
+  - "14"
+  - "15"
+  - "16"

--- a/buildkit/rum.yaml
+++ b/buildkit/rum.yaml
@@ -7,7 +7,8 @@ source: https://github.com/postgrespro/rum/archive/refs/tags/1.3.13.tar.gz
 description: RUM access method - inverted index with additional information in posting lists
 licence: PostgreSQL
 keywords:
-  - rum
+  - rum access method
+  - inverted index
 arch:
   - amd64
   - arm64

--- a/buildkit/rum.yaml
+++ b/buildkit/rum.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 name: rum
 version: "1.3.13"
 homepage: https://github.com/postgrespro/rum
+repository: https://github.com/postgrespro/rum
 source: https://github.com/postgrespro/rum/archive/refs/tags/1.3.13.tar.gz
 description: RUM access method - inverted index with additional information in posting lists
 licence: PostgreSQL

--- a/spec/buildkit.md
+++ b/spec/buildkit.md
@@ -36,6 +36,7 @@ pgVersions:
   - "13"
   - "14"
   - "15"
+  - "16"
 # Build scripts for the extension.
 build:
   # Steps to be executed before the main build process.
@@ -146,7 +147,7 @@ builders:
 ## `source`
 
 - **Description**: Specifies the URI for the extension's source code. The URI can be a HTTP/HTTPS URL or a local file path.
-If the URI is a HTTP/HTTPS URL, it must end with `.tar.gz`.
+  If the URI is a HTTP/HTTPS URL, it must end with `.tar.gz`.
 - **Type**: String
 - **Required**: Yes
 
@@ -161,8 +162,8 @@ If the URI is a HTTP/HTTPS URL, it must end with `.tar.gz`.
 - **Description**: Lists the PostgreSQL versions compatible with the extension. If unspecified, the extension is assumed to be compatible with all versions.
 - **Type**: List of strings
 - **Required**: No
-- **Supported Values**: `"13"`, `"14"`, `"15"`
-- **Default Values**: `"13"`, `"14"`, `"15"`
+- **Supported Values**: `"13"`, `"14"`, `"15"`, `"16"`
+- **Default Values**: `"13"`, `"14"`, `"15"`, `"16"`
 
 ## `license`
 
@@ -232,7 +233,7 @@ build: |
 
 ## `runDependencies`
 
-- **Description**:  Lists the rpackages needed for the extension to function properly at runtime.
+- **Description**: Lists the rpackages needed for the extension to function properly at runtime.
 - **Type**: List of strings
 - **Required**: No
 

--- a/spec/buildkit.md
+++ b/spec/buildkit.md
@@ -13,6 +13,8 @@ name: my-extension
 version: "0.4.4"
 # URL of the extension's homepage.
 homepage: https://github.com/org/repo
+# URL of the extension's repository.
+repository: https://github.com/org/repo
 # URL of the extension's source code. Only `tar.gz` files are supported.
 source: https://github.com/org/repo/archive/refs/tags/v0.4.4.tar.gz
 # Description of the extension.
@@ -148,6 +150,12 @@ builders:
 
 - **Description**: Specifies the URI for the extension's source code. The URI can be a HTTP/HTTPS URL or a local file path.
   If the URI is a HTTP/HTTPS URL, it must end with `.tar.gz`.
+- **Type**: String
+- **Required**: Yes
+
+## `repository`
+
+- **Description**: Specifies the URL for the extension's repository, where users can view the source code in more detail.
 - **Type**: String
 - **Required**: Yes
 


### PR DESCRIPTION
## Adds the following extensions:
- RUM
- HypoPG
- pgRouting

## Buildkit spec updates:
- Includes support for `pgVersions` 16.
- Adds details on `repository` field (with updated example configuration).