### PR TITLE
[HYD-650] Use gha cache instead of registry cache

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -66,8 +66,8 @@ jobs:
           pgxman build \
             --file "$(pwd)/buildkit/${{ matrix.extension }}.yaml" \
             --set "arch=[${{ matrix.arch }}]" \
-            --cache-from "type=registry,ref=ghcr.io/pgxman/buildkit-cache" \
-            --cache-to "type=registry,ref=ghcr.io/pgxman/buildkit-cache,mode=max"
+            --cache-from "type=gha" \
+            --cache-to "type=gha,mode=max"
       - name: Upload Artifacts
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -29,7 +29,7 @@ jobs:
     permissions:
       packages: write
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         arch:
           - amd64


### PR DESCRIPTION
Let's see whether this can work around the registry cache permission issue: https://github.com/pgxman/buildkit/actions/runs/6817909044/job/18542442449?pr=42#step:7:3364