### PR TITLE
Set `--suite` & `--component`

### DIFF
--- a/script/deb-s3-upload
+++ b/script/deb-s3-upload
@@ -15,6 +15,8 @@ for _dir in $_dirs; do
         --prefix "$_prefix" \
         --codename "$_codename" \
         --visibility public \
+        --suite "$_codename" \
+        --component main \
         --sign "$GPG_SIGNING_KEY_ID" \
         --preserve_versions \
         "$*/$_dir/*.deb"


### PR DESCRIPTION
Currently the suite name is `unknown` when running `apt search`:

```
postgresql-16-pgxman-pgvector/unknown 0.5.1 arm64
  Open-source vector similarity search for Postgres.
```

This will set it to the same as codename, e.g. `postgresql-16-pgxman-pgvector/bookworm 0.5.1 arm64`