### PR TITLE
Support pg 16 for pg_later

### DIFF
--- a/buildkit/pg_later.yaml
+++ b/buildkit/pg_later.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 name: pg_later
-version: "0.0.12"
+version: "0.0.12+87ad305"
 homepage: https://github.com/tembo-io/pg_later
 repository: https://github.com/tembo-io/pg_later
-source: https://github.com/tembo-io/pg_later/archive/refs/tags/v0.0.12.tar.gz
+source: https://github.com/tembo-io/pg_later/archive/87ad305387a1fcdf84a4b05b1ff2ec90d64c0e88.tar.gz
 description: Execute SQL now and get the results later.
 license: PostgreSQL
 keywords:
@@ -16,17 +16,17 @@ arch:
 maintainers:
   - name: James Lovern
     email: james@lovern.io
+  - name: Owen Ou
+    email: o@hydra.so
 buildDependencies:
-  - pgxman/pg_partman
   - pgxman/pgmq
 runDependencies:
-  - pgxman/pg_partman
   - pgxman/pgmq
 build:
   pre:
     - name: Install pgrx
       run: |
-        cargo install --locked cargo-pgrx --version 0.9.8
+        cargo install --locked cargo-pgrx --version 0.11.2
   main:
     - name: Build pg_later
       run: |
@@ -35,3 +35,4 @@ build:
 pgVersions:
   - "14"
   - "15"
+  - "16"

--- a/buildkit/pgmq.yaml
+++ b/buildkit/pgmq.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 name: pgmq
-version: "0.33.0"
+version: "1.1.0"
 homepage: https://github.com/tembo-io/pgmq
 repository: https://github.com/tembo-io/pgmq
-source: https://github.com/tembo-io/pgmq/archive/refs/tags/v0.33.0.tar.gz
+source: https://github.com/tembo-io/pgmq/archive/refs/tags/v1.1.0.tar.gz
 description: A lightweight message queue. Like AWS SQS and RSMQ but on Postgres.
 license: PostgreSQL
 keywords:
@@ -15,6 +15,8 @@ arch:
 maintainers:
   - name: James Lovern
     email: james@lovern.io
+  - name: Owen Ou
+    email: o@hydra.so
 buildDependencies:
   - pgxman/pg_partman
 runDependencies:
@@ -23,7 +25,7 @@ build:
   pre:
     - name: Install pgrx
       run: |
-        cargo install --locked cargo-pgrx --version 0.10.2
+        cargo install --locked cargo-pgrx --version 0.11.0
   main:
     - name: Build pgmq
       run: |


### PR DESCRIPTION
* Add pg 16 support for `pg_later` with https://github.com/tembo-io/pg_later/pull/37
* Update `pgmq` to the latest version
* Remove `pg_partman` from `pg_later` dependency list which is not needed explicitly

This fixes https://github.com/pgxman/buildkit/issues/58.