### PR TITLE
Revert amd64 runner to unbuntu-latest

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -38,7 +38,7 @@ jobs:
         extension: ${{ fromJSON(needs.set_matrix.outputs.matrix) }}
         include:
           - arch: amd64
-            runs-on: buildjet-4vcpu-ubuntu-2204
+            runs-on: ubuntu-latest
           - arch: arm64
             runs-on: buildjet-8vcpu-ubuntu-2204-arm
     steps:


### PR DESCRIPTION
From https://github.blog/2024-01-17-github-hosted-runners-double-the-power-for-open-source, we are getting the 4cpu, 16GiB & 150GiB for free, which is what we are paying for buildjet.