### PR TITLE
[ENG-1013] Update buildkits that are not compatible with Ubuntu Noble

### DIFF
--- a/buildkit/multicorn.yaml
+++ b/buildkit/multicorn.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 name: multicorn
-version: "2.4.0+b68b75c"
+version: "2.5.0+d57b998"
 homepage: https://github.com/pgsql-io/multicorn2
 repository: https://github.com/pgsql-io/multicorn2
-source: https://github.com/pgsql-io/multicorn2/archive/b68b75c253be72bdfd5b24bf76705c47c238d370.tar.gz
+source: https://github.com/pgsql-io/multicorn2/archive/d57b9989862329bfc4ff0c70ea52c7b1200ff90d.tar.gz
 description: Multicorn Python3 Wrapper for Postgresql Foreign Data Wrapper. This includes the s3csv_fdw and gspreadsheet_fdw plugins.
 license: PostgreSQL
 keywords:
@@ -21,27 +21,29 @@ build:
   main:
     - name: Build multicorn
       run: |
-        python3.11 -m venv .venv
+        python3 -m venv .venv
         . .venv/bin/activate
-        PYTHON_OVERRIDE=python3.11 make
-        DESTDIR=${DESTDIR} PYTHON_OVERRIDE=python3.11 make install
+        PYTHON_VERSION=$(python -V 2>&1 | grep -oP '(?<=Python )\d+\.\d+')
+        PYTHON_OVERRIDE=python${PYTHON_VERSION} make
+        DESTDIR=${DESTDIR} PYTHON_OVERRIDE=python${PYTHON_VERSION} make install
 
         # install s3csv_fdw & gspreadsheet_fdw
-        python3.11 -m pip install \
+        python3 -m pip install \
           git+https://github.com/hydradatabase/s3csv_fdw@f64e24f9fe3f7dbd1be76f9b8b3b5208f869e5e3 \
           gspread oauth2client git+https://github.com/hydradatabase/gspreadsheet_fdw@d5bc5ae0b2d189abd6d2ee4610bd96ec39602594
 
-        DEST_PYTHON_DIR=${DESTDIR}/usr/local/lib/python3.11/dist-packages
+        DEST_PYTHON_DIR=${DESTDIR}/usr/local/lib/python${PYTHON_VERSION}/dist-packages
         mkdir -p ${DEST_PYTHON_DIR}
-        cp -r .venv/lib/python3.11/site-packages/* ${DEST_PYTHON_DIR}
+        cp -r .venv/lib/python${PYTHON_VERSION}/site-packages/* ${DEST_PYTHON_DIR}
 buildDependencies:
-  - python3.11
-  - python3.11-dev
-  - python3.11-venv
+  - python3
+  - python3-dev
+  - python3-venv
 runDependencies:
-  - python3.11
-  - python3.11-dev
+  - python3
+  - python3-dev
 pgVersions:
   - "13"
   - "14"
   - "15"
+  - "16"

--- a/buildkit/postgis.yaml
+++ b/buildkit/postgis.yaml
@@ -52,3 +52,18 @@ builders:
         signedKey:
           url: https://www.postgresql.org/media/keys/ACCC4CF8.asc
           format: asc
+  ubuntu:noble:
+    runDependencies:: *debRunDeps
+    aptRepositories:
+      - id: pgdg-noble
+        types:
+          - deb
+        uris:
+          - https://apt.postgresql.org/pub/repos/apt
+        suites:
+          - noble-pgdg
+        components:
+          - main
+        signedKey:
+          url: https://www.postgresql.org/media/keys/ACCC4CF8.asc
+          format: asc


### PR DESCRIPTION
This only updates incompatible buildkits. We need to refresh all buildkits to have Noble artifacts later.